### PR TITLE
Changed results to be Result<(),String> rather than Result<(),&str>. …

### DIFF
--- a/src/grammar.rustpeg
+++ b/src/grammar.rustpeg
@@ -11,7 +11,7 @@ rule -> Rule
       match {match expression {
           ActionExpr(ref exprs, _, _) => {
             if attrs.2 && exprs.len() > 0 {
-              Err("code block")
+              Err("code block".to_string())
             } else {
               Ok(())
             }
@@ -19,7 +19,7 @@ rule -> Rule
           _ => {
             if attrs.2 {
                 // require context rules to be code blocks only
-                Err("code block")
+                Err("code block".to_string())
             } else {
               Ok(())
             }

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -203,6 +203,7 @@ pub fn header_items(ctxt: &rustast::ExtCtxt) -> Vec<rustast::P<rustast::Item>> {
 			pub column: usize,
 			pub offset: usize,
 			pub expected: ::std::collections::HashSet<String>,
+			pub msg: Option<String>
 		}
 	).unwrap());
 
@@ -213,7 +214,11 @@ pub fn header_items(ctxt: &rustast::ExtCtxt) -> Vec<rustast::P<rustast::Item>> {
 	items.push(quote_item!(ctxt,
 		impl ::std::fmt::Display for ParseError {
 			fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::result::Result<(), ::std::fmt::Error> {
-				try!(write!(fmt, "error at {}:{}: expected ", self.line, self.column));
+				match self.msg {
+				    Some(ref msg) => {return write!(fmt, "Error at {}:{}: {}", self.line, self.column, msg);},
+				    None => ()
+				}
+				try!(write!(fmt, "Error at {}:{}: expected ", self.line, self.column));
 				if self.expected.len() == 1 {
 					try!(write!(fmt, "`{}`", escape_default(self.expected.iter().next().unwrap())));
 				} else {
@@ -397,6 +402,7 @@ fn compile_rule_export(ctxt: &rustast::ExtCtxt, rule: &Rule) -> rustast::P<rusta
 				column: col,
 				offset: state.max_err_pos,
 				expected: state.expected,
+				msg: None
 			})
 		}
 	)).unwrap()


### PR DESCRIPTION
…This allows users to provide more info while parsing, without needeing to generate an ast
